### PR TITLE
Compute twist in BODY frame for p3d plugin

### DIFF
--- a/gazebo_plugins/src/gazebo_ros_p3d.cpp
+++ b/gazebo_plugins/src/gazebo_ros_p3d.cpp
@@ -250,6 +250,12 @@ void GazeboRosP3D::UpdateChild()
           vpos = frame_pose.rot.RotateVector(vpos - frame_vpos);
           veul = frame_pose.rot.RotateVector(veul - frame_veul);
         }
+        else
+        {
+          const math::Quaternion rot_inv = pose.rot.GetInverse();
+          vpos = rot_inv.RotateVector(vpos);
+          veul = rot_inv.RotateVector(veul);
+        }
 
         // Apply Constant Offsets
         // apply xyz offsets and get position and rotation components


### PR DESCRIPTION
Instead of the twist just in the world frame.

If you think the previous behavior wasn't a bug, I can add an element/param, so I turn the `else` into and `else if`